### PR TITLE
Add sub-project for OCI builds

### DIFF
--- a/oci-hello/.gitignore
+++ b/oci-hello/.gitignore
@@ -1,0 +1,3 @@
+#C++ build
+bin/
+*.o

--- a/oci-hello/Dockerfile
+++ b/oci-hello/Dockerfile
@@ -1,3 +1,4 @@
 FROM gcc:12.2
 
+WORKDIR /src
 CMD echo "Hello World!"

--- a/oci-hello/Dockerfile
+++ b/oci-hello/Dockerfile
@@ -1,0 +1,3 @@
+FROM gcc:12.2
+
+CMD echo "Hello World!"

--- a/oci-hello/Dockerfile
+++ b/oci-hello/Dockerfile
@@ -1,4 +1,4 @@
 FROM gcc:12.2
 
 WORKDIR /src
-CMD echo "Hello World!"
+CMD ["make"]

--- a/oci-hello/Makefile
+++ b/oci-hello/Makefile
@@ -5,6 +5,10 @@ docker := podman.exe
 docker-build:
 	$(docker) build -t kkrull/gcc:latest .
 
+.PHONY: docker-clean
+docker-clean:
+	-$(docker) rmi kkrull/gcc:latest
+
 .PHONY: docker-interactive
 docker-interactive:
 	$(docker) run -it --rm -vsrc:/src kkrull/gcc:latest bash

--- a/oci-hello/Makefile
+++ b/oci-hello/Makefile
@@ -1,5 +1,11 @@
-#TODO KDK: How to detect WSL, or that docker and podman are aliases?
-docker := podman.exe
+PODMAN := $(shell command -v podman.exe 2> /dev/null)
+ifdef PODMAN
+  #Podman on WSL: Use short form to avoid whitespace in Program Files/
+	docker := podman.exe
+else
+  #Native docker installed
+	docker := docker
+endif
 
 .PHONY: docker-build
 docker-build:

--- a/oci-hello/Makefile
+++ b/oci-hello/Makefile
@@ -1,9 +1,9 @@
 PODMAN := $(shell command -v podman.exe 2> /dev/null)
 ifdef PODMAN
-  #Podman on WSL: Use short form to avoid whitespace in Program Files/
+	#Podman on WSL: Use short form to avoid whitespace in Program Files/
 	docker := podman.exe
 else
-  #Native docker installed
+	#Native docker installed
 	docker := docker
 endif
 

--- a/oci-hello/Makefile
+++ b/oci-hello/Makefile
@@ -1,13 +1,14 @@
+#TODO KDK: How to detect WSL, or that docker and podman are aliases?
+docker := podman.exe
 
 .PHONY: docker-build
 docker-build:
-	docker build -t kkrull/gcc:latest .
-
-.PHONY: docker-run
-docker-run:
-	docker run --rm kkrull/gcc:latest
+	$(docker) build -t kkrull/gcc:latest .
 
 .PHONY: docker-interactive
 docker-interactive:
-	echo "TODO KDK: Add volume mount to eventually use for sources and Makefile"
-	docker run -it --rm kkrull/gcc:latest bash
+	$(docker) run -it --rm -vsrc:/src kkrull/gcc:latest bash
+
+.PHONY: docker-run
+docker-run:
+	$(docker) run --rm -vsrc:/src kkrull/gcc:latest

--- a/oci-hello/Makefile
+++ b/oci-hello/Makefile
@@ -1,0 +1,5 @@
+
+.PHONY: docker-build
+
+docker-build:
+	docker build -t kkrull/gcc:latest .

--- a/oci-hello/Makefile
+++ b/oci-hello/Makefile
@@ -6,3 +6,8 @@ docker-build:
 .PHONY: docker-run
 docker-run:
 	docker run --rm kkrull/gcc:latest
+
+.PHONY: docker-interactive
+docker-interactive:
+	echo "TODO KDK: Add volume mount to eventually use for sources and Makefile"
+	docker run -it --rm kkrull/gcc:latest bash

--- a/oci-hello/Makefile
+++ b/oci-hello/Makefile
@@ -1,5 +1,8 @@
 
 .PHONY: docker-build
-
 docker-build:
 	docker build -t kkrull/gcc:latest .
+
+.PHONY: docker-run
+docker-run:
+	docker run --rm kkrull/gcc:latest

--- a/oci-hello/README.md
+++ b/oci-hello/README.md
@@ -1,0 +1,4 @@
+# OCI Hello World
+
+Use an OCI (a.k.a Docker, podman) container to build C++ for Linux with
+[GCC](https://hub.docker.com/_/gcc).

--- a/oci-hello/README.md
+++ b/oci-hello/README.md
@@ -2,3 +2,15 @@
 
 Use an OCI (a.k.a Docker, podman) container to build C++ for Linux with
 [GCC](https://hub.docker.com/_/gcc).
+
+## What compiler?
+
+Ok so I was a little lost since last using g++ about 20 years ago, and I couldn't remember if that
+was still a thing.  Apparently it is - it's the C++ front-end for the GNU Compiler Collection (GCC).
+This post describes the diffeerence between `gcc` and `g++`:
+<https://stackoverflow.com/a/173007/112682>
+
+## Usage
+
+Who has time to remember how to run Docker?  Just use the `Makefile`!
+

--- a/oci-hello/README.md
+++ b/oci-hello/README.md
@@ -14,5 +14,3 @@ This post describes the diffeerence between `gcc` and `g++`:
 
 Who has time to remember how to run Docker?  Just use the `Makefile`!
 
-TODO KDK: Add volume mount when running the container, to see if it can view a file.  Try running it
-in interactive mode first

--- a/oci-hello/README.md
+++ b/oci-hello/README.md
@@ -14,3 +14,5 @@ This post describes the diffeerence between `gcc` and `g++`:
 
 Who has time to remember how to run Docker?  Just use the `Makefile`!
 
+TODO KDK: Add volume mount when running the container, to see if it can view a file.  Try running it
+in interactive mode first

--- a/oci-hello/README.md
+++ b/oci-hello/README.md
@@ -14,3 +14,11 @@ This post describes the diffeerence between `gcc` and `g++`:
 
 Who has time to remember how to run Docker?  Just use the `Makefile`!
 
+```shell
+make docker-build #Build the dev image
+make docker-run #Runs `make` in the container, working at src/
+make docker-interactive #Start an interactive session in the container
+```
+
+When finished, the contents of `src/` are updated with whatever that `Makefile`
+produces (e.g. a compiled program).

--- a/oci-hello/src/Makefile
+++ b/oci-hello/src/Makefile
@@ -1,0 +1,26 @@
+# Compiler settings
+
+uname := $(shell uname)
+ifeq ($(uname), Darwin)
+	CXX := clang++
+	CXXFLAGS := -std=c++11 -stdlib=libc++
+endif
+
+# Project settings
+
+sources := $(wildcard *.cpp)
+objects := $(patsubst %.cpp,%.o,$(sources))
+output_dir := bin
+executable := $(output_dir)/helloworld
+
+$(executable): $(objects)
+	@mkdir -p $(output_dir)
+	$(CXX) $(CXXFLAGS) -o $(executable) $(objects)
+	@echo "Created: $(executable)"
+
+.PHONY: clean
+clean:
+	rm -Rf $(executable) $(objects)
+
+run: $(executable)
+	@$(executable)

--- a/oci-hello/src/helloworld.cpp
+++ b/oci-hello/src/helloworld.cpp
@@ -1,0 +1,5 @@
+#include <iostream>
+
+int main() {
+  std::cout << "Hello World!" << std::endl;
+}


### PR DESCRIPTION
Show how to use an OCI image (e.g. Docker, Podman) to do a C++ build, without having to have the tools installed on your own machine.